### PR TITLE
Added github repo to dist metadata

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -89,6 +89,11 @@ my $build = $class->new
 		      'ExtUtils::CBuilder' => 0,
 		      ($^O =~ /^(dos|MSWin32)$/ ? ('ExtUtils::Install' => 1.39) : ()),
 		     },
+   meta_merge => {
+      resources => {
+         repository => 'https://github.com/rjbs/PathTools'
+      }
+   },
    xs_files       => { 'Cwd.xs' => 'lib/Cwd.xs' },
    extra_compiler_flags => \@compiler_flags,
    dynamic_config => 1,  # Because of the $^O checking above

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl distribution PathTools.
 
+3.61 - 
+- Added github repo to dist metadata
+
 3.60 - Wed Nov 18 21:28:01 EST 2015
 - add File::Spec::AmigaOS -- and actually ship it, this time
 


### PR DESCRIPTION
I'm guessing that the `Makefile.PL` was generated by `Module::Build`, and so doesn't need the github repo adding there as well?